### PR TITLE
Use the latest ruspiro-crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "ruspiro-sdk"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.1.0" # remember to update html_root_url
-description = "Combine the RusPiRo crates into a SDK library for convinient usage, providing feature gates for the individual parts."
+version = "0.2.0" # remember to update html_root_url
+description = """
+Combine the RusPiRo crates into a SDK library for convinient usage, providing feature gates for the individual parts.
+"""
 license = "Apache-2.0"
-repository = "https://github.com/RusPiRo/ruspiro-sdk/tree/v0.1.0"
-documentation = "https://docs.rs/ruspiro-sdk/0.1.0"
+repository = "https://github.com/RusPiRo/ruspiro-sdk"
+documentation = "https://docs.rs/ruspiro-sdk/0.2.0"
 readme = "README.md"
 keywords = ["RusPiRo", "baremetal", "raspberrypi", "sdk"]
 categories = ["no-std", "embedded"]
@@ -13,30 +15,37 @@ edition = "2018"
 
 [badges]
 travis-ci = { repository = "RusPiRo/ruspiro-sdk", branch = "master" }
-is-it-maintained-issue-resolution = { repository = "RusPiRo/ruspiro-sdk" }
-is-it-maintained-open-issues = { repository = "RusPiRo/ruspiro-sdk" }
 maintenance = { status = "actively-developed" }
 
 [lib]
 
 [dependencies]
-ruspiro-boot = { version = "0.1.0", features = ["with_panic", "with_exception"], optional = true }
-ruspiro-register = "0.1.1"
-ruspiro-gpio = "0.1.0"
-ruspiro-mailbox = "0.1.0"
-ruspiro-timer = "0.1.0"
-ruspiro-interrupt = "0.1.0"
-ruspiro-allocator = { version = "0.1.1", optional = true }
-ruspiro-console = { version = "0.1.1", optional = true}
-ruspiro-uart = { version = "0.1.0", optional = true }
-ruspiro-i2c = { version = "0.1.0", optional = true }
+ruspiro-boot = { version = "0.2", features = ["with_panic", "with_exception"], optional = true }
+ruspiro-lock = "0.2"
+ruspiro-singleton = "0.2"
+ruspiro-register = "0.1"
+ruspiro-gpio = "0.2"
+ruspiro-mailbox = "0.2"
+ruspiro-timer = "0.1"
+ruspiro-cache = "0.1"
+ruspiro-interrupt = "0.2"
+ruspiro-allocator = { version = "0.2", optional = true }
+ruspiro-console = { version = "0.2", optional = true}
+ruspiro-uart = { version = "0.2", optional = true }
+ruspiro-i2c = { version = "0.2", optional = true }
 
 [features]
-default = ["with_boot", "with_allocator"]
+default = ["ruspiro_pi3", "with_boot", "with_allocator", "with_uart"]
 ruspiro_pi3 = [
+    "ruspiro-boot/ruspiro_pi3",
     "ruspiro-mailbox/ruspiro_pi3",
     "ruspiro-timer/ruspiro_pi3",
     "ruspiro-interrupt/ruspiro_pi3",
+    "ruspiro-uart/ruspiro_pi3",
+    "ruspiro-cache/ruspiro_pi3",
+    "ruspiro-gpio/ruspiro_pi3",
+    "ruspiro-i2c/ruspiro_pi3",
+    "ruspiro-lock/ruspiro_pi3",
     "ruspiro-uart/ruspiro_pi3"
 ]
 with_boot = ["ruspiro-boot"]
@@ -44,3 +53,11 @@ with_allocator = ["ruspiro-allocator"]
 with_console = ["ruspiro-console"]
 with_uart = ["ruspiro-uart", "with_console"]
 with_i2c = ["ruspiro-i2c"]
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "armv7-unknown-linux-gnueabihf"
+rustc-args = [
+    "-C target-cpu=cortex-a53",
+    "-C target-feature=+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon"
+]

--- a/README.md
+++ b/README.md
@@ -11,28 +11,32 @@ below...
 
 
 ## Usage
-To use the crate just add the following dependency to your ``Cargo.toml`` file. The components of the sdk crate could be configured using feature gates. The most important one is to set the ``ruspiro_pi3`` feature to enable compiling the peripheral address space and Raspberry Pi 3 specific components successfully.
+To use the crate just add the following dependency to your ``Cargo.toml`` file. The components of the system development kit could be configured using feature gates. The available features are listed in the table below.
 ```
 [dependencies]
-ruspiro-sdk = { version = "0.1.0", features = ["ruspiro_pi3"]
+ruspiro-sdk = "0.2"
 ```
 
 The always usable crates are:
 
 - [``ruspiro-register``](https://crates.io/crates/ruspiro-register)
+- [``ruspiro-lock``](https://crates.io/crates/ruspiro-lock)
+- [``ruspiro-singleton``](https://crates.io/crates/ruspiro-singleton)
 - [``ruspiro-gpio``](https://crates.io/crates/ruspiro-gpio)
 - [``ruspiro-mailbox``](https://crates.io/crates/ruspiro-mailbox)
 - [``ruspiro-timer``](https://crates.io/crates/ruspiro-timer)
+- [``ruspiro-cache``](https://crates.io/crates/ruspiro-cache)
 - [``ruspiro-interrupt``](https://crates.io/crates/ruspiro-interrupt)
 
-Additional features/crates are:
+### Features:
 
 | Feature            | Default | Description |
 |--------------------|---------|-------------|
+| ``ruspiro_pi3``    | yes     | Forwarded to the dependend crates to enable Raspberry Pi3 specific compilation, e.g. provide the proper base address for MMIO register.|
 | ``with_boot``      | yes     | Bundle the [``ruspiro-boot``](https://crates.io/crates/ruspiro-boot) crate into the sdk package providing Raspberry Pi boot code.|
 | ``with_allocator`` | yes     | Bundle the [``ruspiro-allocator``](https://crates.io/crates/ruspiro-allocator) crate into the sdk package|
 | ``with_console``   | no      | Bundle the [``ruspiro-console``](https://crates.io/crates/ruspiro-console) crate into the sdk package. This requires an allocator to be present. |
-| ``with_uart``      | no      | Bundle the [``ruspiro-uart``](https://crates.io/crates/ruspiro-uart) crate into the sdk package. This will always bundle ``ruspiro-console`` and does also require an allocator to be present.|
+| ``with_uart``      | no      | Bundle the [``ruspiro-uart``](https://crates.io/crates/ruspiro-uart) crate into the sdk package. This will always bundle ``ruspiro-console`` and does also require an allocator to be present. So either provide your own or activate the ``with_alocator`` feature as well. |
 | ``with_i2c``       | no      | Bundle the [``ruspiro-i2c``](https://crates.io/crates/ruspiro-i2c) crate into the sdk package. This requires an allocator to be present. |
 
 

--- a/makefile
+++ b/makefile
@@ -26,22 +26,13 @@ all:
 # update dependend crates to their latest version if any
 	cargo update
 # cross compile the crate
-	cargo xbuild --target $(TARGET) --release
+	cargo xbuild --lib --target $(TARGET) --release
 
 doc:
 	# update dependend crates to their latest version if any
 	cargo update
 	# build docu for this crate using custom target
-	xargo doc --all --target $(TARGET) --release --open
-	
-test:
-	xargo test --doc --target $(TARGET)
-
-publish-dry-run:
-	xargo publish --dry-run --target $(TARGET)
-
-publish:
-	xargo publish --target $(TARGET)
+	xargo doc --lib --target $(TARGET) --release --open
 
 clean:
 	cargo clean

--- a/scenario-1/Cargo.toml
+++ b/scenario-1/Cargo.toml
@@ -3,11 +3,15 @@ name = "rpi-kernel"
 version = "0.0.1"
 edition = "2018"
 
+[workspace]
+
 [[bin]]
 name ="kernel7"
 path = "src/kernel.rs"
 
-[dependencies]
-ruspiro-sdk = { path = "../../ruspiro-sdk", features = [
-        "ruspiro_pi3"
-    ] }
+[dependencies.ruspiro-sdk]
+path = "../."
+version = "0.2"
+features = [
+    "ruspiro_pi3"
+]

--- a/scenario-1/makefile
+++ b/scenario-1/makefile
@@ -24,7 +24,7 @@ export RUSTFLAGS = -C linker=arm-eabi-gcc.exe -C target-cpu=cortex-a53 -C target
 # build the current crate
 all:  
 # cross compile the crate
-	cargo xbuild --target $(TARGET) --release
+	cargo xbuild --bins --target $(TARGET) --release
 
 clean:
 	cargo clean

--- a/scenario-1a/Cargo.toml
+++ b/scenario-1a/Cargo.toml
@@ -8,6 +8,7 @@ name ="kernel7"
 path = "src/kernel.rs"
 
 [dependencies.ruspiro-sdk]
-path = "../../ruspiro-sdk"
+path = "../."
+version = "0.2"
 default-features = false
 features = ["ruspiro_pi3"]

--- a/scenario-2/Cargo.toml
+++ b/scenario-2/Cargo.toml
@@ -3,12 +3,16 @@ name = "rpi-kernel"
 version = "0.0.1"
 edition = "2018"
 
+[workspace]
+
 [[bin]]
 name ="kernel7"
 path = "src/kernel.rs"
 
-[dependencies]
-ruspiro-sdk = { path = "../../ruspiro-sdk", features = [
-        "ruspiro_pi3",
-        "with_uart"
-    ] }
+[dependencies.ruspiro-sdk]
+path = "../."
+version = "0.2"
+features = [
+    "ruspiro_pi3",
+    "with_uart"
+]

--- a/scenario-2/makefile
+++ b/scenario-2/makefile
@@ -24,7 +24,7 @@ export RUSTFLAGS = -C linker=arm-eabi-gcc.exe -C target-cpu=cortex-a53 -C target
 # build the current crate
 all:  
 # cross compile the crate
-	cargo xbuild --target $(TARGET) --release
+	cargo xbuild --bins --target $(TARGET) --release
 
 clean:
 	cargo clean

--- a/scenario-2/src/kernel.rs
+++ b/scenario-2/src/kernel.rs
@@ -10,7 +10,7 @@
 //! # Scenarion 2 - use Uart/Console with built-in boot
 //! 
 //! When the one-time initialization is called due to coming alive we retrieve the current core clock rate via a mailbox
-//! call and use this to initialize the Uart0 to be used as the console output channel. If everything went fine the
+//! call and use this to initialize the Uart1 (minUart) to be used as the console output channel. If everything went fine the
 //! LED connected to GPIO pin 17 will be lit and one core after the other will write to the console that he has started
 //! thinking.
 
@@ -25,7 +25,7 @@ fn alive(core: u32) {
         MAILBOX.take_for(|mb| mb.get_clockrate(ArmClockId::Core))
             .and_then(|core_rate| {
                 // using this to initialize the UART
-                let mut uart = Uart0::new();
+                let mut uart = uart::Uart1::new();
                 uart.initialize(core_rate, 115_200).map(|_| uart)
             }).and_then(|uart| {
                 // set the uart as current console output channel

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
  * Author: André Borrmann 
  * License: Apache License 2.0
  **********************************************************************************************************************/
-#![doc(html_root_url = "https://docs.rs/ruspiro-sdk/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/ruspiro-sdk/0.2.0")]
 #![no_std]
 
 //! # RusPiRo System development kit library
@@ -14,10 +14,13 @@
 //! 
 //! The always usable crates are:
 //! - [``ruspiro-register``](https://crates.io/crates/ruspiro-register)
+//! - [``ruspiro-lock``](https://crates.io/crates/ruspiro-lock)
+//! - [``ruspiro-singleton``](https:://create.io/crates/ruspiro-singleton)
 //! - [``ruspiro-gpio``](https://crates.io/crates/ruspiro-gpio)
 //! - [``ruspiro-mailbox``](https://crates.io/crates/ruspiro-mailbox)
 //! - [``ruspiro-timer``](https://crates.io/crates/ruspiro-timer)
 //! - [``ruspiro-interrupt``](https://crates.io/crates/ruspiro-interrupt)
+//! - [``ruspiro-cache``](https://crates.io/crates/ruspiro-cache)
 //! 
 //! Additional features/crates are:
 //! 
@@ -38,11 +41,16 @@ pub use ruspiro_register::{define_register, define_registers, RegisterField, Reg
 pub use ruspiro_gpio::GPIO;
 pub use ruspiro_mailbox::{MAILBOX, ArmClockId};
 pub use ruspiro_timer as timer;
+pub use ruspiro_singleton::Singleton;
+pub use ruspiro_lock as lock;
 
 #[allow(unused_imports)]
 #[macro_use]
-extern crate ruspiro_interrupt;
+pub extern crate ruspiro_interrupt;
 pub use ruspiro_interrupt::*;
+
+#[allow(unused_imports)]
+pub use ruspiro_cache as cache;
 
 #[cfg(feature = "with_boot")]
 #[allow(unused_imports)]
@@ -63,7 +71,7 @@ extern crate ruspiro_console;
 pub use ruspiro_console::{CONSOLE, print, println, info, warn, error};
 
 #[cfg(feature = "with_uart")]
-pub use ruspiro_uart::Uart0;
+pub use ruspiro_uart as uart;//{Uart0, Uart1};
 
 #[cfg(feature = "with_i2c")]
 pub use ruspiro_i2c::{I2C, I2cDevice};


### PR DESCRIPTION
Use the latest versions and fix some dependency settings regarding forwarding features.
Now ``ruspiro_pi3`` and ``with_uart`` are also default features.